### PR TITLE
Ctrl+C doesn't work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN \
   apt-get update && apt-get install --no-install-recommends python-pip build-essential python-dev -y && \
   pip install gunicorn httpbin && \
   echo '#!/bin/bash' > run.sh && \
-  echo 'gunicorn --bind=0.0.0.0:8000 httpbin:app' >> run.sh && \
+  echo 'exec gunicorn --bind=0.0.0.0:8000 httpbin:app' >> run.sh && \
   chmod +x run.sh && \
   apt-get remove --purge build-essential python-dev -y && \
   apt-get autoremove -y && \


### PR DESCRIPTION
This little fix makes ctrl+c work properly (also it won't take 10 secs to shutdown with docker-compose). Gunicorn will now have PID 1 and docker will try to stop gunicorn process which knows how to handle signals, not bash.